### PR TITLE
Fix CLA workflow: use cla-signatures branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
                   path-to-signatures: 'signatures/version1/cla.json'
                   path-to-document: 'https://github.com/safeinsights/trusted-output-app/blob/main/CLA.md'
                   # branch should not be protected
-                  branch: 'main'
+                  branch: 'cla-signatures'
                   allowlist: bot*,battibatch,chrisbendel,jbwilson8,jpslav,kswanson33,nathanstitt,philschatz,rnathuji,Rod0352,scb6,sparksam, stetradis,therealmarv
 
                   # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken


### PR DESCRIPTION
Action was failing with 'Unexpected end of JSON input' because signatures file lived on protected main. Move storage to dedicated cla-signatures branch.