### PR TITLE
Triage Trivy CVEs (vite, multer, ws) + dead package.json entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "trusted-output-app",
     "version": "0.0.1",
     "description": "Trusted Output App",
-    "main": "index.js",
     "packageManager": "pnpm@11.1.3",
     "engines": {
         "node": ">=22",


### PR DESCRIPTION
## Summary

Triage of three Trivy HIGH findings from June 16–18 scans. **All three CVEs are already resolved on `main`** — this PR documents the triage and removes one dead `package.json` entry found during the dependency review.

### CVE status

| CVE | Package | Flagged | Status |
| --- | --- | --- | --- |
| CVE-2026-53571 | vite 8.0.13 | dev-only (via vitest / vite-tsconfig-paths) | **Fixed** — lockfile already pins vite 8.0.16 (patched) since 9e531b5 "Updated Vitest for vulnerabilities check" |
| CVE-2026-5079 | multer 2.1.1 | was a direct dep of the old Next.js app | **Gone** — removed entirely with the Next.js stack in #51 |
| CVE-2026-48779 | ws 8.20.1 | was transitive via next | **Gone** — removed entirely with the Next.js stack in #51 |

The scans (June 16–18) predate the Next.js removal (merged July 8). A re-scan against current `main` should come back clean for all three — `pnpm audit` reports no known vulnerabilities.

### Dependency utilization review

Audited every direct dependency for actual usage:

- `jsonwebtoken`, `uuid`, `si-encryption` — used in `src/`
- `@types/debug` — looks unused but is load-bearing: `si-encryption` ships raw TS whose `lib/logger.ts` imports `debug`; typecheck fails without it (verified empirically)
- All eslint/prettier/vitest devDependencies — wired into `eslint.config.mjs` / `vitest.config.mjs` / scripts
- `main: "index.js"` — pointed at a file that does not exist (pre-Next.js leftover); removed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)